### PR TITLE
Fix: "Namespace already defined" bug.

### DIFF
--- a/war-src/js/openEditor/round_robin.js
+++ b/war-src/js/openEditor/round_robin.js
@@ -3,11 +3,24 @@
 
 goog.provide("plt.wescheme.RoundRobin");
 
-goog.require('plt.compiler.lex');
-goog.require('plt.compiler.parse');
-goog.require('plt.compiler.desugar');
-goog.require('plt.compiler.analyze');
-goog.require('plt.compiler.compile');
+
+/* BUGFIX:
+ * 
+ * plt.wescheme.RoundRobin has the following requirements.
+ *   Unfortunately, due to a bug in the way that dependencies are handled,
+ *   Closure attempts to include compiler/structures.js multiple times. This
+ *   causes the following error:
+ *
+ *     Uncaught Error: Namespace "plt.compiler.throwError" already declared
+ *
+ *   The fix is to have files that require this file also require the following files.
+ *   See run.js for an example.
+ */
+//goog.require('plt.compiler.lex');
+//goog.require('plt.compiler.parse');
+//goog.require('plt.compiler.desugar');
+//goog.require('plt.compiler.analyze');
+//goog.require('plt.compiler.compile');
 
 (function() {
     "use strict";

--- a/war-src/js/run.js
+++ b/war-src/js/run.js
@@ -2,11 +2,25 @@
 // openEditor, but stripped down since it does not need to support
 // interactive evaluation.
 
+goog.provide("plt.wescheme.runner");
+
 goog.require("plt.wescheme.AjaxActions");
 goog.require("plt.wescheme.WeSchemeProperties");
 goog.require("plt.wescheme.makeDynamicModuleLoader");
 goog.require("plt.wescheme.RoundRobin");
-goog.provide("plt.wescheme.runner");
+
+
+/* BUGFIX:
+ * 
+ * These #includes are required by plt.wescheme.RoundRobin.
+ * See round_robin.js for more details.
+ */
+goog.require('plt.compiler.lex');
+goog.require('plt.compiler.parse');
+goog.require('plt.compiler.desugar');
+goog.require('plt.compiler.analyze');
+goog.require('plt.compiler.compile');
+
 
 (function() {
 


### PR DESCRIPTION
The bug is due to the way dependencies are handled by Closure. This addresses it.