### PR TITLE
Change AppEngine Deployment target to wescheme-hrd-2

### DIFF
--- a/war/WEB-INF/appengine-web.xml
+++ b/war/WEB-INF/appengine-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-	<application>wescheme</application>
+	<application>wescheme-hrd-2</application>
 	<version>189</version>
 	
 	<!-- Configure java.util.logging -->


### PR DESCRIPTION
This ensures that future updates to WeScheme are directed to the correct deployment.
The codebase at the initial migration to HRD is at this exact commit.

Please merge this only after the migration is complete (at 0600 2015-05-15 GMT+0000)