### PR TITLE
Fix updating the OAuth credentials

### DIFF
--- a/war-src/js/openEditor/config.js
+++ b/war-src/js/openEditor/config.js
@@ -1,4 +1,4 @@
 goog.provide('plt.config');
 
-plt.config.APP_ID = "wescheme";    // The app ID associated with the App Engine project
-plt.config.CLIENT_ID = "900483279628-lpbjh0vro7oub29asb9n6b8atojfjo8k.apps.googleusercontent.com"   // The Client key associated with the Google APIs project
+plt.config.APP_ID = "wescheme-hrd-2";    // The app ID associated with the App Engine project
+plt.config.CLIENT_ID = "981340394888-d28ji2vus7h06du2hgum27sf1mjs7ssm.apps.googleusercontent.com"   // The Client key associated with the Google APIs project


### PR DESCRIPTION
This fixes the authentication error when using Google Picker to pick an image.

This was manually tested via development server.