### PR TITLE
Improved build support for Windows

### DIFF
--- a/build-console-and-editor.rkt
+++ b/build-console-and-editor.rkt
@@ -39,10 +39,18 @@
                          (make-directory* (path-only pipe-output-to)))
                        (open-output-file pipe-output-to #:exists 'replace))
                      (current-output-port)))
+
+  (define resolved-cmd-standard
+    (if (file-exists? cmd) cmd
+      (find-executable-path cmd)))
+
+  (define resolved-cmd-windows
+    (and (equal? (system-type) 'windows) 
+         (and (string? cmd)
+              (find-executable-path (string-append cmd ".exe")))))
+
   (define resolved-cmd
-    (if (file-exists? cmd)
-        cmd
-        (find-executable-path cmd)))
+    (or resolved-cmd-standard resolved-cmd-windows))
 
   (unless resolved-cmd
     (error 'build (format "I could not find ~s in your PATH" cmd)))


### PR DESCRIPTION
Building for Windows was problematic, as the build script was looking for apps (java,python,git,unzip)without their ".exe" extension: Racket did not find them. 

Note that the dependency 'dyoo/closure-compile' still fails when looking for java without the ".exe", leading to the workaround:
>A softlink to the java executable (java.exe), but without the ".exe" needs to be defined the current directory. In bash, one can be created with the command:
>   ln -s "C:\Program Files (x86)\Java\jdk1.7.0_79\bin\java.exe" java '''
